### PR TITLE
[CI] Add Black lint as Github Action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  black:
+    name: Black Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Black Lint
+        uses: psf/black@stable
+        with:
+          options: "--check"


### PR DESCRIPTION
Black Lint is a powerful python linting tool to help make code prettier and more conferment to PEP8.
This `Lint` workflow will run on every pull request & commit and display the output (whether or not the python code is formatted)